### PR TITLE
브랜치 및 마지막 커밋 조회 기능 구현 및 Jackson 설정 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:22.04
+
+RUN apt update && \
+    apt install -y git openssh-server openjdk-17-jdk curl unzip && \
+    useradd -m -s /bin/bash gituser && \
+    mkdir /var/run/sshd && \
+    mkdir -p /home/gituser/repos && \
+    chown -R gituser:gituser /home/gituser
+
+EXPOSE 22 8080
+
+COPY build/libs/git-server.jar /app/git-server.jar
+
+RUN mkdir -p /home/gituser/.ssh && \
+    chmod 700 /home/gituser/.ssh && \
+    chown -R gituser:gituser /home/gituser/.ssh
+
+CMD ["sh", "-c", "service ssh start && java -jar /app/git-server.jar"]

--- a/src/main/java/com/example/gitserver/config/JacksonConfig.java
+++ b/src/main/java/com/example/gitserver/config/JacksonConfig.java
@@ -1,0 +1,17 @@
+package com.example.gitserver.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+        return mapper;
+    }
+}

--- a/src/main/java/com/example/gitserver/controller/BranchController.java
+++ b/src/main/java/com/example/gitserver/controller/BranchController.java
@@ -1,0 +1,28 @@
+package com.example.gitserver.controller;
+
+import com.example.gitserver.dto.BranchDto;
+import com.example.gitserver.dto.RepoInfoDto;
+import com.example.gitserver.service.BranchService;
+import com.example.gitserver.service.RepoService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/branch")
+@RequiredArgsConstructor
+public class BranchController {
+
+    private final BranchService branchService;
+
+    @GetMapping("/branch/{owner}/{repo}")
+    public ResponseEntity<List<BranchDto>> getBranches(@PathVariable String owner, @PathVariable String repo) {
+        List<BranchDto> branches = branchService.getBranches(owner, repo);
+        return ResponseEntity.ok(branches);
+    }
+
+}

--- a/src/main/java/com/example/gitserver/dto/BranchDto.java
+++ b/src/main/java/com/example/gitserver/dto/BranchDto.java
@@ -1,0 +1,7 @@
+package com.example.gitserver.dto;
+
+public record BranchDto(
+        String name,
+        CommitDto lastCommit
+) {
+}

--- a/src/main/java/com/example/gitserver/dto/CommitDto.java
+++ b/src/main/java/com/example/gitserver/dto/CommitDto.java
@@ -1,0 +1,11 @@
+package com.example.gitserver.dto;
+
+public record CommitDto(
+        String sha,
+        String message,
+        String writerId,
+        String date,
+        String parent,
+        String secondParent
+) {
+}

--- a/src/main/java/com/example/gitserver/service/BranchService.java
+++ b/src/main/java/com/example/gitserver/service/BranchService.java
@@ -1,0 +1,103 @@
+package com.example.gitserver.service;
+
+import com.example.gitserver.dto.BranchDto;
+import com.example.gitserver.dto.CommitDto;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class BranchService {
+    public List<BranchDto> getBranches(String owner, String repo) {
+        String repoPath = "/home/" + owner + "/" + repo + ".git";
+        File gitDir = new File(repoPath);
+
+        List<String> branchNames = getBranchNames(gitDir);
+        List<BranchDto> branchDtos = new ArrayList<>();
+
+        for (String branch : branchNames) {
+            CommitDto lastCommit = getLastCommitForBranch(gitDir, branch);
+            if (lastCommit != null) {
+                branchDtos.add(new BranchDto(branch, lastCommit));
+            }
+        }
+
+        return branchDtos;
+    }
+
+    private List<String> getBranchNames(File gitDir) {
+        List<String> branches = new ArrayList<>();
+        ProcessBuilder pb = new ProcessBuilder("git", "for-each-ref", "--format=%(refname:short)", "refs/heads/");
+        pb.directory(gitDir);
+
+        try {
+            Process process = pb.start();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    branches.add(line.trim());
+                }
+            }
+
+            if (process.waitFor() != 0) {
+                throw new RuntimeException("브랜치 목록 조회 실패: " + readErrorOutput(process));
+            }
+
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("브랜치 정보를 가져오는 중 오류 발생", e);
+        }
+
+        return branches;
+    }
+
+    private CommitDto getLastCommitForBranch(File gitDir, String branch) {
+        ProcessBuilder pb = new ProcessBuilder(
+                "git", "log", branch, "-1",
+                "--pretty=format:%H|%s|%an|%cd|%P",
+                "--date=iso"
+        );
+        pb.directory(gitDir);
+
+        try {
+            Process process = pb.start();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String line = reader.readLine();
+                if (line == null || line.isBlank()) {
+                    return null;
+                }
+
+                String[] parts = line.split("\\|", -1);
+                String sha = safePart(parts, 0);
+                String message = safePart(parts, 1);
+                String author = safePart(parts, 2);
+                String date = safePart(parts, 3);
+                String[] parents = safePart(parts, 4).split(" ");
+
+                String parent = parents.length > 0 ? parents[0] : null;
+                String secondParent = parents.length > 1 ? parents[1] : null;
+
+                return new CommitDto(sha, message, author, date, parent, secondParent);
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException("커밋 정보 조회 실패 (브랜치: " + branch + ")", e);
+        }
+    }
+
+    private String readErrorOutput(Process process) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+            return reader.lines().collect(Collectors.joining(System.lineSeparator()));
+        }
+    }
+
+    private String safePart(String[] parts, int index) {
+        return (index < parts.length) ? parts[index] : "";
+    }
+}


### PR DESCRIPTION
### ✨ 주요 변경 사항
- BranchService, BranchController 추가
- 특정 저장소의 브랜치 목록과 각 브랜치의 마지막 커밋 정보를 조회하는 기능 구현
- CommitDto, BranchDto 추가
- 커밋과 브랜치 정보를 담는 DTO 생성
- JacksonConfig 설정 추가
- 클라이언트와의 네이밍 컨벤션 일치를 위해 PropertyNamingStrategies.SNAKE_CASE 적용
- Dockerfile 작성
- Ubuntu 기반으로 OpenJDK, SSH, Git 설치 및 jar 실행 환경 구성

🧪 테스트
- Postman으로 GET /branch/{owner}/{repo} 호출 시 정상적으로 브랜치와 커밋 정보 반환 확인
- 클라이언트(Feign)에서 SNAKE_CASE로 직렬화되어 정상 응답 처리 확인

🔧 참고
- 클라이언트 측에서 Feign 오류(Unrecognized field "lastCommit") 발생 → Jackson의 네이밍 전략 불일치 문제 해결
- Jackson 설정은 서버 쪽에서 SNAKE_CASE로 통일하여 문제 해결함