### PR TITLE
브랜치 머지 기능 추가

### DIFF
--- a/src/main/java/com/example/gitserver/controller/RepoController.java
+++ b/src/main/java/com/example/gitserver/controller/RepoController.java
@@ -1,15 +1,14 @@
 package com.example.gitserver.controller;
 
+import com.example.gitserver.dto.MergeDto;
 import com.example.gitserver.dto.RepoInfoDto;
 import com.example.gitserver.service.RepoService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @RequestMapping("/repo")
@@ -19,8 +18,16 @@ public class RepoController {
     private final RepoService repoService;
 
     @PostMapping
-    public ResponseEntity<Void> createRepo(@Valid @RequestBody RepoInfoDto repoInfoDto){
+    public ResponseEntity<Void> createRepo(@Valid @RequestBody RepoInfoDto repoInfoDto) {
         repoService.createRepo(repoInfoDto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
+
+
+    @PostMapping("/{owner}/{repo}")
+    public ResponseEntity<Void> mergeBranch(@PathVariable String owner,@PathVariable String repo, @RequestBody MergeDto mergeDto) {
+        repoService.mergeBranch(owner,repo,mergeDto);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
 }

--- a/src/main/java/com/example/gitserver/dto/MergeDto.java
+++ b/src/main/java/com/example/gitserver/dto/MergeDto.java
@@ -1,0 +1,10 @@
+package com.example.gitserver.dto;
+
+public record MergeDto(
+        String base,
+        String head,
+        String commitTitle,
+        String commitMessage,
+        String mergeMethod
+) {
+}

--- a/src/main/java/com/example/gitserver/service/RepoService.java
+++ b/src/main/java/com/example/gitserver/service/RepoService.java
@@ -1,10 +1,23 @@
 package com.example.gitserver.service;
 
 
+import com.example.gitserver.dto.BranchDto;
+import com.example.gitserver.dto.CommitDto;
+import com.example.gitserver.dto.MergeDto;
 import com.example.gitserver.dto.RepoInfoDto;
 import org.springframework.stereotype.Service;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 public class RepoService {
@@ -22,4 +35,83 @@ public class RepoService {
         }
 
     }
+
+
+    public void mergeBranch(String owner, String repo, MergeDto mergeDto) {
+        String baseBranch = mergeDto.base();
+        String headBranch = mergeDto.head();
+        String commitMessage = mergeDto.commitTitle() + "\n\n" + mergeDto.commitMessage();
+        String mergeMethod = mergeDto.mergeMethod(); // "merge", "squash", "rebase"
+
+        String repoPath = "/home/" + owner + "/" + repo + ".git";
+        String fileRepoUrl = "file:///" + repoPath.replace("\\", "/");
+
+        File tempDir = null;
+
+        try {
+            tempDir = Files.createTempDirectory("git-merge-").toFile();
+
+            runGit(tempDir.getParentFile(), "git", "clone", fileRepoUrl, tempDir.getName());
+            File repoDir = new File(tempDir.getParent(), tempDir.getName());
+
+            runGit(repoDir, "git", "fetch", "origin");
+
+            runGit(repoDir, "git", "checkout", "-b", headBranch, "origin/" + headBranch);
+
+            runGit(repoDir, "git", "checkout", baseBranch);
+
+            switch (mergeMethod.toLowerCase()) {
+                case "squash" -> {
+                    runGit(repoDir, "git", "merge", "--squash", headBranch);
+                    runGit(repoDir, "git", "commit", "-m", commitMessage);
+                }
+                case "rebase" -> {
+                    runGit(repoDir, "git", "rebase", headBranch);
+                }
+                default -> {
+                    runGit(repoDir, "git", "merge", "--no-ff", "-m", commitMessage, headBranch);
+                }
+            }
+
+            runGit(repoDir, "git", "push", "origin", baseBranch);
+
+        } catch (IOException e) {
+            throw new RuntimeException("병합 작업 실패 (디렉토리 생성 오류)", e);
+        } finally {
+            if (tempDir != null) {
+                deleteDirectory(tempDir);
+            }
+        }
+    }
+
+    private void runGit(File dir, String... command) {
+        try {
+            ProcessBuilder pb = new ProcessBuilder(command);
+            pb.directory(dir);
+            pb.redirectErrorStream(true);
+            Process process = pb.start();
+
+            String output;
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                output = reader.lines().collect(Collectors.joining("\n"));
+            }
+
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                throw new RuntimeException("Git 명령 실패: " + String.join(" ", command) + "\n" + output);
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Git 명령 실행 중 예외 발생", e);
+        }
+    }
+
+    private void deleteDirectory(File dir) {
+        try (Stream<Path> walk = Files.walk(dir.toPath())) {
+            walk.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+        } catch (IOException e) {
+            System.err.println("임시 디렉토리 삭제 실패: " + e.getMessage());
+        }
+    }
+
+
 }


### PR DESCRIPTION
## ✨ 주요 변경 사항

- 브랜치 병합 기능(merge API) 추가
- 사용자로부터 base, head 브랜치 및 머지 전략 정보를 받아 Git 병합 실행
- squash, rebase, merge 전략 지원
- bare repository에 직접 병합이 불가능한 점을 고려하여, 임시 clone 후 병합 수행
- 병합 완료 후 origin(base) 브랜치에 push
- 병합 후 임시 작업 디렉토리는 자동 삭제

## 🛠 API 정보

- **Endpoint**: `POST /repo/{owner}/{repo}`
- **Request Body (`MergeDto`)**:
  ```json
  {
    "base": "main",
    "head": "feature/login",
    "commitTitle": "✨ 로그인 기능 병합",
    "commitMessage": "JWT 인증 및 로그인 로직 구현 완료",
    "mergeMethod": "merge" // or squash, rebase
  }

## 💢 트러블 슈팅

문제 상황 | 원인 | 해결 방법
-- | -- | --
fatal: this operation must be run in a work tree | bare repo는 work tree가 없기 때문에 checkout, merge 불가 | 임시 clone 후 병합 작업 수행
Windows 환경에서 file:/// 경로 이상 | 윈도우 경로는 백슬래시 → 슬래시 변환 필요 | repoPath.replace("\\", "/") 처리로 해결

## ✔ 배운 점
1. Bare Repository는 .git 디렉토리만 존재하고, 실제 코드(work tree)는 없는 구조다.
이로 인해 staging area가 없으므로 git commit을 수행할 수 없고,
파일이 없기 때문에 git merge, git checkout 등의 명령도 사용할 수 없다.

2. 그렇다면 왜 bare repo를 사용할까?
공동 작업을 위한 중앙 저장소 역할로 사용되며, 커밋 데이터만 저장하면 되기 때문에 파일 수정 위험이 없어 안정성이 높다.

3. GitHub 역시 PR 병합 시 bare repo에서 직접 merge를 수행하지 않는다.
대신 내부적으로 임시 작업 디렉토리 혹은 Git 엔진(libgit2, merge-ort 등)을 활용해 병합을 처리한 뒤, 그 결과를 bare repo에 push하는 방식으로 동작한다.
즉, clone → merge → push의 흐름을 따른다.

참고: https://github.blog/engineering/infrastructure/scaling-merge-ort-across-github (2023.07.27)

4. 병합 방식에 따른 차이점:
- git merge (일반 병합, --no-ff): 새로운 병합 커밋을 생성하며, 기존 커밋 히스토리를 그대로 유지한다. 브랜치의 흐름을 명확히 보여주기 때문에 협업 시 유용하다.

- git merge --squash: feature 브랜치의 여러 커밋을 하나로 압축해 병합한다. 병합 커밋은 생성되지 않고 일반 커밋 하나만 생성되므로, 개별 커밋 기록은 남지 않는다.

- git rebase: feature 브랜치의 커밋들을 main 브랜치 위로 재배치한다. 히스토리가 일직선(linear)으로 정리되어 로그가 깔끔해지지만, 커밋의 SHA가 바뀌므로 주의가 필요하다.


