### PR TITLE
브랜치 비교 기능 추가

### DIFF
--- a/src/main/java/com/example/gitserver/controller/BranchController.java
+++ b/src/main/java/com/example/gitserver/controller/BranchController.java
@@ -1,6 +1,7 @@
 package com.example.gitserver.controller;
 
 import com.example.gitserver.dto.BranchDto;
+import com.example.gitserver.dto.CompareBranchResponseDto;
 import com.example.gitserver.dto.RepoInfoDto;
 import com.example.gitserver.service.BranchService;
 import com.example.gitserver.service.RepoService;
@@ -19,10 +20,22 @@ public class BranchController {
 
     private final BranchService branchService;
 
-    @GetMapping("/branch/{owner}/{repo}")
+    @GetMapping("/{owner}/{repo}")
     public ResponseEntity<List<BranchDto>> getBranches(@PathVariable String owner, @PathVariable String repo) {
         List<BranchDto> branches = branchService.getBranches(owner, repo);
         return ResponseEntity.ok(branches);
     }
+
+    @GetMapping("/{owner}/{repo}/compare/{base}/{head}")
+    public ResponseEntity<List<CompareBranchResponseDto>> compareBranchHead(
+            @PathVariable String owner,
+            @PathVariable String repo,
+            @PathVariable String base,
+            @PathVariable String head
+    ) {
+        List<CompareBranchResponseDto> branches = branchService.compareBranchHead(owner, repo,base,head);
+        return ResponseEntity.ok(branches);
+    }
+
 
 }

--- a/src/main/java/com/example/gitserver/dto/CompareBranchResponseDto.java
+++ b/src/main/java/com/example/gitserver/dto/CompareBranchResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.gitserver.dto;
+
+public record CompareBranchResponseDto(
+        String message,
+        String writerName,
+        String date,
+        String direction
+) {
+
+}


### PR DESCRIPTION
### ✨ 주요 변경 사항
- `GET /{owner}/{repo}/compare/{base}/{head}` API 추가  
  → 기준 브랜치(`base`)와 비교 브랜치(`head`) 간 커밋 비교 결과 반환
- `BranchController`에 비교 API 엔드포인트 추가
- `BranchService`에 Git CLI 기반 비교 로직 구현
- `CompareBranchResponseDto` 레코드 클래스 추가 (message, writerName, date, direction)

### 🛠 API 정보
- 엔드 포인트
`GET /{owner}/{repo}/compare/{base}/{head}`
- Path Variables

| 변수 | 설명 |
|------|------|
| `owner` | 사용자 이름 |
| `repo` | 리포지토리 이름 |
| `base` | 기준 브랜치 |
| `head` | 비교 대상 브랜치 |

-  Response 예시
```json
[
  {
    "message": "test commit",
    "writerName": "kimjungminn24",
    "date": "2025-04-12 17:38:10 +0900",
    "direction": "head"
  },
  {
    "message": "merge completed",
    "writerName": "kimjungminn24",
    "date": "2025-04-11 17:47:39 +0900",
    "direction": "base"
  }
]
```
### 💢 트러블슈팅


문제상황 | 원인 | 해결방법
-- | -- | --
Git 출력이 예상과 다르게 두 줄로 나옴 | git rev-list --left-right --pretty=format: 명령어의 출력이 commit >SHA 줄과 SHA\|message\|author\|date 줄로 분리됨 | commit > 또는 commit < 줄에서 먼저 direction 값을 저장한 뒤, 다음 줄에서 커밋 정보를 파싱하도록 로직을 수정
커밋 정보 줄에서 방향 판단이 안 됨 | 방향 정보(<, >)는 commit 줄에만 존재하고, 커밋 정보 줄에는 없음 | 방향 판단은 commit 줄에서만 수행하고, 커밋 정보 줄에서는 저장된 direction을 그대로 사용
Git 출력 구조가 공식 문서에 자세히 설명되어 있지 않음 | --left-right와 --pretty=format 조합의 출력 형식이 Git 문서에서 상세히 다루어지지 않음 | 직접 출력 결과를 분석하여, 줄별 의미를 명확히 파악하고 파싱 구조를 설계함

### ✔ 배운 점
1. git 명령어 정리

명령어 | 설명
-- | --
git rev-list base...head | base와 head 브랜치의 공통 조상 이후의 커밋들을 출력함
--left-right | 공통 조상 이후에 어느 브랜치에만 존재하는 커밋인지 표시→ >: head에만 있음, <: base에만 있음
--pretty=format: | 커밋 정보를 사용자 지정 형식으로 출력예: %H=SHA, %s=메시지, %an=작성자, %cd=날짜
--date=iso | 날짜를 ISO 8601 형식(YYYY-MM-DD) 으로 출력

### ❓ 왜 git diff, git log 대신 git rev-list를 사용했는가


비교 대상 | 이유
-- | --
git diff base...head | 파일 변경 내용을 보여주는 용도로는 적절하지만, 커밋 단위의 비교(작성자, 메시지, 날짜 포함)를 할 수 없음
git log base..head | 한쪽 브랜치의 커밋만 보여줌. 방향 구분 없이 전체 로그를 나열하므로, 어떤 커밋이 base에만 있는지, head에만 있는지 명확하게 파악하기 어려움
git log --left-right base...head | 방향 구분이 가능하지만, --pretty=format과 같이 사용할 경우 방향 기호(<, >)가 출력되지 않음 → 별도로 파싱하기 까다로움
 git rev-list --left-right base...head | 가장 간단하면서도 명확하게 방향 정보(<, >)를 제공해주고, --pretty=format과 안정적으로 함께 사용 가능해서 구조적으로 파싱하기 쉬움
