### PR TITLE
Git 명령 실행을 위한 유틸 함수 도입 

### DIFF
--- a/src/main/java/com/example/gitserver/service/BranchService.java
+++ b/src/main/java/com/example/gitserver/service/BranchService.java
@@ -2,26 +2,24 @@ package com.example.gitserver.service;
 
 import com.example.gitserver.dto.BranchDto;
 import com.example.gitserver.dto.CommitDto;
+import com.example.gitserver.dto.CompareBranchResponseDto;
+import com.example.gitserver.util.GitCommandUtil;
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class BranchService {
-    public List<BranchDto> getBranches(String owner, String repo) {
-        String repoPath = "/home/" + owner + "/" + repo + ".git";
-        File gitDir = new File(repoPath);
 
-        List<String> branchNames = getBranchNames(gitDir);
+    public List<BranchDto> getBranches(String owner, String repo) {
+        File gitDir = getGitDirectory(owner, repo);
         List<BranchDto> branchDtos = new ArrayList<>();
 
-        for (String branch : branchNames) {
+        for (String branch : getBranchNames(gitDir)) {
             CommitDto lastCommit = getLastCommitForBranch(gitDir, branch);
             if (lastCommit != null) {
                 branchDtos.add(new BranchDto(branch, lastCommit));
@@ -31,24 +29,47 @@ public class BranchService {
         return branchDtos;
     }
 
-    private List<String> getBranchNames(File gitDir) {
-        List<String> branches = new ArrayList<>();
-        ProcessBuilder pb = new ProcessBuilder("git", "for-each-ref", "--format=%(refname:short)", "refs/heads/");
-        pb.directory(gitDir);
+    public List<CompareBranchResponseDto> compareBranchHead(String owner, String repo, String base, String head) {
+        File gitDir = getGitDirectory(owner, repo);
+        List<CompareBranchResponseDto> result = new ArrayList<>();
 
-        try {
-            Process process = pb.start();
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    branches.add(line.trim());
+        List<String> command = List.of(
+                "git", "rev-list", "--left-right", "--pretty=format:%H|%s|%an|%cd",
+                "--date=iso", base + "..." + head
+        );
+
+        try (BufferedReader reader = GitCommandUtil.execute(gitDir, command)) {
+            String direction = "unknown";
+            String line;
+            String commitPrefix = "commit ";
+
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty()) continue;
+
+                if (line.startsWith(commitPrefix)) {
+                    direction = extractDirection(line, commitPrefix);
+                } else {
+                    result.add(parseCommitInfo(line, direction));
                 }
             }
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("브랜치 비교 중 오류 발생", e);
+        }
 
-            if (process.waitFor() != 0) {
-                throw new RuntimeException("브랜치 목록 조회 실패: " + readErrorOutput(process));
+        return result;
+    }
+
+    private List<String> getBranchNames(File gitDir) {
+        List<String> branches = new ArrayList<>();
+        List<String> command = List.of("git", "for-each-ref", "--format=%(refname:short)", "refs/heads/");
+
+        try (BufferedReader reader = GitCommandUtil.execute(gitDir, command)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                branches.add(line.trim());
             }
-
         } catch (IOException | InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("브랜치 정보를 가져오는 중 오류 발생", e);
@@ -57,47 +78,55 @@ public class BranchService {
         return branches;
     }
 
+
     private CommitDto getLastCommitForBranch(File gitDir, String branch) {
-        ProcessBuilder pb = new ProcessBuilder(
+        List<String> command = List.of(
                 "git", "log", branch, "-1",
                 "--pretty=format:%H|%s|%an|%cd|%P",
                 "--date=iso"
         );
-        pb.directory(gitDir);
 
-        try {
-            Process process = pb.start();
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-                String line = reader.readLine();
-                if (line == null || line.isBlank()) {
-                    return null;
-                }
+        try (BufferedReader reader = GitCommandUtil.execute(gitDir, command)) {
+            String line = reader.readLine();
+            if (line == null || line.isBlank()) return null;
 
-                String[] parts = line.split("\\|", -1);
-                String sha = safePart(parts, 0);
-                String message = safePart(parts, 1);
-                String author = safePart(parts, 2);
-                String date = safePart(parts, 3);
-                String[] parents = safePart(parts, 4).split(" ");
+            String[] parts = line.split("\\|", -1);
+            String sha = safePart(parts, 0);
+            String message = safePart(parts, 1);
+            String author = safePart(parts, 2);
+            String date = safePart(parts, 3);
+            String[] parents = safePart(parts, 4).split(" ");
 
-                String parent = parents.length > 0 ? parents[0] : null;
-                String secondParent = parents.length > 1 ? parents[1] : null;
-
-                return new CommitDto(sha, message, author, date, parent, secondParent);
-            }
-
-        } catch (IOException e) {
+            return new CommitDto(sha, message, author, date,
+                    parents.length > 0 ? parents[0] : null,
+                    parents.length > 1 ? parents[1] : null);
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException("커밋 정보 조회 실패 (브랜치: " + branch + ")", e);
         }
     }
 
-    private String readErrorOutput(Process process) throws IOException {
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
-            return reader.lines().collect(Collectors.joining(System.lineSeparator()));
-        }
+    private CompareBranchResponseDto parseCommitInfo(String line, String direction) {
+        String[] parts = line.split("\\|", -1);
+        return new CompareBranchResponseDto(
+                safePart(parts, 1), // message
+                safePart(parts, 2), // author
+                safePart(parts, 3), // date
+                direction
+        );
+    }
+
+    private String extractDirection(String line, String prefix) {
+        if (line.startsWith(prefix + ">")) return "head";
+        if (line.startsWith(prefix + "<")) return "base";
+        return "unknown";
     }
 
     private String safePart(String[] parts, int index) {
         return (index < parts.length) ? parts[index] : "";
+    }
+
+    private File getGitDirectory(String owner, String repo) {
+        return new File("/home/" + owner + "/" + repo + ".git");
     }
 }

--- a/src/main/java/com/example/gitserver/service/BranchService.java
+++ b/src/main/java/com/example/gitserver/service/BranchService.java
@@ -62,20 +62,10 @@ public class BranchService {
     }
 
     private List<String> getBranchNames(File gitDir) {
-        List<String> branches = new ArrayList<>();
         List<String> command = List.of("git", "for-each-ref", "--format=%(refname:short)", "refs/heads/");
-
-        try (BufferedReader reader = GitCommandUtil.execute(gitDir, command)) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                branches.add(line.trim());
-            }
-        } catch (IOException | InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("브랜치 정보를 가져오는 중 오류 발생", e);
-        }
-
-        return branches;
+        return GitCommandUtil.executeLines(gitDir, command).stream()
+                .map(String::trim)
+                .toList();
     }
 
 

--- a/src/main/java/com/example/gitserver/service/RepoService.java
+++ b/src/main/java/com/example/gitserver/service/RepoService.java
@@ -1,22 +1,16 @@
 package com.example.gitserver.service;
 
-
-import com.example.gitserver.dto.BranchDto;
-import com.example.gitserver.dto.CommitDto;
 import com.example.gitserver.dto.MergeDto;
 import com.example.gitserver.dto.RepoInfoDto;
+import com.example.gitserver.util.GitCommandUtil;
 import org.springframework.stereotype.Service;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Service
@@ -26,10 +20,7 @@ public class RepoService {
         try {
             File repoDir = new File("/home/" + info.userName() + "/" + info.repoName() + ".git");
             repoDir.mkdirs();
-            ProcessBuilder pb = new ProcessBuilder("git", "init", "--bare");
-            pb.directory(repoDir);
-            Process process = pb.inheritIO().start();
-            process.waitFor();
+            GitCommandUtil.executeLines(repoDir, List.of("git", "init", "--bare"));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -51,29 +42,28 @@ public class RepoService {
         try {
             tempDir = Files.createTempDirectory("git-merge-").toFile();
 
-            runGit(tempDir.getParentFile(), "git", "clone", fileRepoUrl, tempDir.getName());
-            File repoDir = new File(tempDir.getParent(), tempDir.getName());
+            File tempParent = tempDir.getParentFile();
+            String tempName = tempDir.getName();
+            File repoDir = new File(tempParent, tempName);
 
-            runGit(repoDir, "git", "fetch", "origin");
-
-            runGit(repoDir, "git", "checkout", "-b", headBranch, "origin/" + headBranch);
-
-            runGit(repoDir, "git", "checkout", baseBranch);
+            GitCommandUtil.executeLines(tempParent, List.of("git", "clone", fileRepoUrl, tempName));
+            GitCommandUtil.executeLines(repoDir, List.of("git", "fetch", "origin"));
+            GitCommandUtil.executeLines(repoDir, List.of("git", "checkout", "-b", headBranch, "origin/" + headBranch));
+            GitCommandUtil.executeLines(repoDir, List.of("git", "checkout", baseBranch));
 
             switch (mergeMethod.toLowerCase()) {
                 case "squash" -> {
-                    runGit(repoDir, "git", "merge", "--squash", headBranch);
-                    runGit(repoDir, "git", "commit", "-m", commitMessage);
+                    GitCommandUtil.executeLines(repoDir, List.of("git", "merge", "--squash", headBranch));
+                    GitCommandUtil.executeLines(repoDir, List.of("git", "commit", "-m", commitMessage));
                 }
                 case "rebase" -> {
-                    runGit(repoDir, "git", "rebase", headBranch);
+                    GitCommandUtil.executeLines(repoDir, List.of("git", "rebase", headBranch));
                 }
                 default -> {
-                    runGit(repoDir, "git", "merge", "--no-ff", "-m", commitMessage, headBranch);
+                    GitCommandUtil.executeLines(repoDir, List.of("git", "merge", "--no-ff", "-m", commitMessage, headBranch));
                 }
             }
-
-            runGit(repoDir, "git", "push", "origin", baseBranch);
+            GitCommandUtil.executeLines(repoDir, List.of("git", "push", "origin", baseBranch));
 
         } catch (IOException e) {
             throw new RuntimeException("병합 작업 실패 (디렉토리 생성 오류)", e);
@@ -84,26 +74,6 @@ public class RepoService {
         }
     }
 
-    private void runGit(File dir, String... command) {
-        try {
-            ProcessBuilder pb = new ProcessBuilder(command);
-            pb.directory(dir);
-            pb.redirectErrorStream(true);
-            Process process = pb.start();
-
-            String output;
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-                output = reader.lines().collect(Collectors.joining("\n"));
-            }
-
-            int exitCode = process.waitFor();
-            if (exitCode != 0) {
-                throw new RuntimeException("Git 명령 실패: " + String.join(" ", command) + "\n" + output);
-            }
-        } catch (IOException | InterruptedException e) {
-            throw new RuntimeException("Git 명령 실행 중 예외 발생", e);
-        }
-    }
 
     private void deleteDirectory(File dir) {
         try (Stream<Path> walk = Files.walk(dir.toPath())) {

--- a/src/main/java/com/example/gitserver/util/GitCommandUtil.java
+++ b/src/main/java/com/example/gitserver/util/GitCommandUtil.java
@@ -1,0 +1,45 @@
+package com.example.gitserver.util;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class GitCommandUtil {
+
+    private GitCommandUtil(){
+
+    }
+
+    public static BufferedReader execute(File directory, List<String> command)
+            throws IOException, InterruptedException {
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.directory(directory);
+
+        Process process = pb.start();
+
+        if (!process.waitFor(5, TimeUnit.SECONDS)) {
+            process.destroy();
+            throw new RuntimeException("Git 명령어 실행 시간 초과: " + String.join(" ", command));
+        }
+
+        if (process.exitValue() != 0) {
+            String error = readErrorOutput(process);
+            throw new RuntimeException("Git 명령어 실행 실패: " + String.join(" ", command) + "\n" + error);
+        }
+
+        return new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
+    }
+
+    private static String readErrorOutput(Process process) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+            return reader.lines().collect(Collectors.joining(System.lineSeparator()));
+        }
+    }
+
+}

--- a/src/main/java/com/example/gitserver/util/GitCommandUtil.java
+++ b/src/main/java/com/example/gitserver/util/GitCommandUtil.java
@@ -42,4 +42,17 @@ public class GitCommandUtil {
         }
     }
 
+    public static List<String> executeLines(File directory, List<String> command) {
+        try (BufferedReader reader = execute(directory, command)) {
+            return reader.lines().collect(Collectors.toList());
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Git 명령어 실행 중 오류 발생: " + String.join(" ", command), e);
+        }
+    }
+
+    public static String executeAndGetOutput(File directory, List<String> command) {
+        return String.join("\n", executeLines(directory, command));
+    }
+
 }


### PR DESCRIPTION
### ✨ 주요 변경 사항
- 지난 PR에 커밋 빼먹은 브랜치 비교 기능 추가
- 커밋 로그 파싱 및 방향 정보(base, head) 추출 로직 추가
- executeLines, executeAndGetOutput 등 Git 명령 실행을 위한 유틸 함수 도입
- 기존 ProcessBuilder 중복을 제거하고, Git 명령 실행 시 에러 처리 및 재사용성을 높이기 위해 공통 유틸 함수 도입

