### PR TITLE
브랜치 간 파일 변경 API 추가 

### DIFF
--- a/src/main/java/com/example/gitserver/controller/BranchController.java
+++ b/src/main/java/com/example/gitserver/controller/BranchController.java
@@ -2,6 +2,7 @@ package com.example.gitserver.controller;
 
 import com.example.gitserver.dto.BranchDto;
 import com.example.gitserver.dto.CompareBranchResponseDto;
+import com.example.gitserver.dto.FileDto;
 import com.example.gitserver.dto.RepoInfoDto;
 import com.example.gitserver.service.BranchService;
 import com.example.gitserver.service.RepoService;
@@ -36,6 +37,18 @@ public class BranchController {
         List<CompareBranchResponseDto> branches = branchService.compareBranchHead(owner, repo,base,head);
         return ResponseEntity.ok(branches);
     }
+
+    @GetMapping("/{owner}/{repo}/compare/{base}/{head}/file")
+    public ResponseEntity<List<FileDto>> getChangeFiles(
+            @PathVariable String owner,
+            @PathVariable String repo,
+            @PathVariable String base,
+            @PathVariable String head
+    ) {
+        List<FileDto> branches = branchService.getChangedFiles(owner, repo,base,head);
+        return ResponseEntity.ok(branches);
+    }
+
 
 
 }

--- a/src/main/java/com/example/gitserver/dto/DiffEntry.java
+++ b/src/main/java/com/example/gitserver/dto/DiffEntry.java
@@ -1,0 +1,8 @@
+package com.example.gitserver.dto;
+
+public record DiffEntry(
+        String filename,
+        int additions,
+        int deletions,
+        String patch
+) {}

--- a/src/main/java/com/example/gitserver/dto/FileContext.java
+++ b/src/main/java/com/example/gitserver/dto/FileContext.java
@@ -1,0 +1,10 @@
+package com.example.gitserver.dto;
+
+import java.io.File;
+import java.util.Map;
+
+public record FileContext(
+        File gitDir,
+        String repoName,
+        Map<String, String> statusMap
+) {}

--- a/src/main/java/com/example/gitserver/dto/FileDto.java
+++ b/src/main/java/com/example/gitserver/dto/FileDto.java
@@ -1,0 +1,13 @@
+package com.example.gitserver.dto;
+
+public record FileDto(
+        String filename,
+        String fileSha,
+        String status,
+        int additions,
+        int deletions,
+        int changes,
+        String patch,
+        String content
+) {
+}

--- a/src/main/java/com/example/gitserver/service/BranchService.java
+++ b/src/main/java/com/example/gitserver/service/BranchService.java
@@ -1,16 +1,15 @@
 package com.example.gitserver.service;
 
-import com.example.gitserver.dto.BranchDto;
-import com.example.gitserver.dto.CommitDto;
-import com.example.gitserver.dto.CompareBranchResponseDto;
+import com.example.gitserver.dto.*;
 import com.example.gitserver.util.GitCommandUtil;
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.nio.file.Files;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class BranchService {
@@ -61,13 +60,85 @@ public class BranchService {
         return result;
     }
 
+    public List<FileDto> getChangedFiles(String owner, String repo, String base, String head) {
+        File gitDir = getGitDirectory(owner, repo);
+        Map<String, String> statusMap = extractFileStatuses(gitDir, base, head);
+        List<String> diffOutput = extractDiffOutput(gitDir, base, head);
+
+        FileContext context = new FileContext(gitDir, repo, statusMap);
+        return parseDiffOutput(context, diffOutput);
+    }
+
+
+    private Map<String, String> extractFileStatuses(File gitDir, String base, String head) {
+        List<String> command = List.of("git", "diff", "--name-status", base + "..." + head);
+        return GitCommandUtil.executeLines(gitDir, command).stream()
+                .map(line -> line.trim().split("\\s+"))
+                .filter(parts -> parts.length >= 2)
+                .collect(Collectors.toMap(parts -> parts[1], parts -> parts[0]));
+    }
+
+    private List<String> extractDiffOutput(File gitDir, String base, String head) {
+        List<String> command = List.of("git", "diff", "--numstat", "--patch", base + "..." + head);
+        return GitCommandUtil.executeLines(gitDir, command);
+    }
+
+    private List<FileDto> parseDiffOutput(FileContext context, List<String> diffOutput) {
+        List<FileDto> result = new ArrayList<>();
+
+        String filename = null;
+        int additions = 0;
+        int deletions = 0;
+        StringBuilder patch = new StringBuilder();
+
+        for (String line : diffOutput) {
+            if (line.matches("^\\d+\\s+\\d+\\s+.+$")) {
+                if (filename != null) {
+                    result.add(buildFileDto(context, new DiffEntry(filename, additions, deletions, patch.toString())));
+                    patch.setLength(0);
+                }
+
+                String[] parts = line.split("\\s+", 3);
+                additions = Integer.parseInt(parts[0]);
+                deletions = Integer.parseInt(parts[1]);
+                filename = parts[2];
+            } else if (filename != null) {
+                patch.append(line).append("\n");
+            }
+        }
+
+        if (filename != null) {
+            result.add(buildFileDto(context, new DiffEntry(filename, additions, deletions, patch.toString())));
+        }
+
+        return result;
+    }
+
+
+    private FileDto buildFileDto(FileContext context, DiffEntry entry) {
+        String status = context.statusMap().getOrDefault(entry.filename(), "M");
+        String sha = computeFileSha(context, entry.filename(), status);
+        String content = loadFileContent(context, entry.filename(), status);
+        int changes = entry.additions() + entry.deletions();
+
+        return new FileDto(
+                entry.filename(),
+                sha,
+                status,
+                entry.additions(),
+                entry.deletions(),
+                changes,
+                entry.patch(),
+                content
+        );
+    }
+
     private List<String> getBranchNames(File gitDir) {
         List<String> command = List.of("git", "for-each-ref", "--format=%(refname:short)", "refs/heads/");
         return GitCommandUtil.executeLines(gitDir, command).stream()
                 .map(String::trim)
                 .toList();
     }
-
 
     private CommitDto getLastCommitForBranch(File gitDir, String branch) {
         List<String> command = List.of(
@@ -95,6 +166,34 @@ public class BranchService {
             throw new RuntimeException("커밋 정보 조회 실패 (브랜치: " + branch + ")", e);
         }
     }
+    private String computeFileSha(FileContext context, String filename, String status) {
+        if (status.equals("D")) return "DELETED";
+
+        File repoRoot = context.gitDir().getParentFile();
+        File file = new File(repoRoot, context.repoName() + File.separator + filename);
+
+        if (!file.exists()) return "MISSING";
+
+        return GitCommandUtil.executeLines(repoRoot, List.of("git", "hash-object", context.repoName() + "/" + filename))
+                .stream().findFirst().orElse("UNKNOWN");
+    }
+
+    private String loadFileContent(FileContext context, String filename, String status) {
+        if (status.equals("D")) return null;
+
+        File repoRoot = context.gitDir().getParentFile();
+        File file = new File(repoRoot, context.repoName() + File.separator + filename);
+
+        if (!file.exists()) return null;
+
+        try {
+            byte[] contentBytes = Files.readAllBytes(file.toPath());
+            return Base64.getEncoder().encodeToString(contentBytes);
+        } catch (IOException e) {
+            throw new RuntimeException("파일 읽기 실패: " + file.getAbsolutePath(), e);
+        }
+    }
+
 
     private CompareBranchResponseDto parseCommitInfo(String line, String direction) {
         String[] parts = line.split("\\|", -1);


### PR DESCRIPTION
### ✨ 주요 변경 사항
- `GET /repos/{owner}/{repo}/branches/compare/{base}/{head}/files` API 추가
- 기준 브랜치와 비교 브랜치 간 변경된 파일 목록을 조회 및 비교하는 기능 구현

```
getChangedFiles()
├─ extractFileStatuses()     → 각 파일의 변경 상태(A: 추가, M: 수정, D: 삭제)를 추출
├─ extractDiffOutput()       → 변경된 파일들의 줄 수와 patch 내용 전체를 텍스트 형태로 가져옴
├─ parseDiffOutput()         → diffOutput을 분석해서 파일 단위로 나누고, 각 파일에 대해 buildFileDto() 호출
│   ├─ DiffEntry 구성
│   └─ buildFileDto()
│       ├─ computeFileSha()      → 파일의 Git SHA-1 해시를 계산함
│       └─ loadFileContent()     → 실제 파일 내용을 디스크에서 읽고 base64 인코딩하여 반환
└─ List<FileDto> 반환


```

### 🛠 API 정보
-  Endpoint `GET /repos/{owner}/{repo}/branches/compare/{base}/{head}/files `
- Path Variables

변수 | 설명
-- | --
owner | 사용자 이름
repo | 리포지토리 이름
base | 기준 브랜치 이름
head | 비교할 브랜치 이름

- Response 예시
```
[
    {
        "filename": "README.MD",
        "file_sha": "fce45d69a7f8f7cc92652d1ad2c94bab4455fb34",
        "status": "M",
        "additions": 3,
        "deletions": 1,
        "changes": 4,
        "patch": "\ndiff --git a/README.MD b/README.MD\nindex c396d53..fce45d6 100644\n--- a/README.MD\n+++ b/README.MD\n@@ -1 +1,3 @@\n-# 테스트 저장소\n+# 테스트 변경\n+\n+## 추가된 줄\n",
        "content": "IyDthYzsiqTtirgg67OA6rK9DQoNCiMjIOy2lOqwgOuQnCDspIQNCg=="
    }
]
```

### 💢 트러블슈팅

문제 상황 | 원인 | 해결 방법
-- | -- | --
git hash-object 실행 실패 | 삭제된 파일을 대상으로 SHA 계산 시도 | status == D인 경우 SHA 계산 생략하고 "DELETED"로 대체
파일 내용 읽기 실패 | 파일이 .git 기준 경로에 없거나 워킹 디렉토리에 없음 | gitDir.getParent() + repoName + filename 형태로 경로 재구성
FileDto에 인자가 너무 많아짐 | buildFileDto() 메서드 파라미터 과다 | FileContext, DiffEntry로 파라미터 객체화하여 정리
content가 계속 null로 나옴 | 실제 파일 경로가 잘못되었거나 존재하지 않음 | 파일 존재 여부 검사(.exists()) 후 base64 인코딩 수행, 실패 시 null 반환


### ✔ 배운 점

용어 / 명령어 | 개념 설명
-- | --
blob | 파일의 실제 내용 그 자체를 저장하는 Git 객체. 같은 내용이면 동일한 SHA-1 해시를 가짐.
tree | 하나의 디렉토리 단위. 내부에 여러 개의 blob(파일)과 다른 tree(서브디렉토리)를 포함함. 즉, 파일 구조를 표현함.
commit | 특정 시점의 스냅샷을 의미. 하나의 tree를 가리키며, 커밋 메시지, 작성자, 부모 커밋 등의 메타데이터를 포함함.
git ls-tree | 특정 커밋이나 트리 객체의 디렉토리 구조를 조회할 때 사용. tree 내부에 어떤 blob/tree가 있는지 확인 가능.
git cat-file -p <SHA> | SHA에 해당하는 Git 객체(blob/tree/commit 등)의 실제 내용을 출력함. Git 내부 객체 확인용으로 자주 사용됨.
git rev-parse <ref> | 브랜치 이름, HEAD, 태그 등을 정확한 SHA-1 해시로 변환하는 명령어. Git 내부 참조 해석기 역할.

### ✍ 고민한 점
 
- 처음에는 Git의 내부 객체 구조를 직접 활용해 브랜치 간 변경을 비교하려고 시도했음.
즉, 각 커밋의 tree 객체를 통해 하위 blob 파일들을 순회하고, blob 해시(SHA)를 직접 비교하여 변경 여부를 판단하려 함
→ 이 과정에서 git ls-tree, git cat-file -p, git rev-parse 같은 명령어를 활용해 구조를 탐색했음
- 하지만 이런 방식은 구조적으로 복잡할 뿐 아니라, A/M/D 상태 파악이나 patch 정보를 추출하는 데에도 직접 구현이 많이 필요하다는 한계를 느꼈음
- 이후 Git에는 이미 내부 비교 결과를 사람이 읽기 좋은 형태로 출력해주는 고수준 명령어들이 존재함을 확인함.
예를 들어

```
git diff --name-status: 변경된 파일의 상태(A/M/D)
git diff --numstat: 줄 수 변화 (additions/deletions)
git diff --patch: diff patch 내용
```
이들을 조합하면 비교 결과를 쉽게 수집할 수 있었음.

- Git 명령어는 파일 단위로 정보를 제공하지 않고 "스트림"처럼 라인별로 던져주기 때문에, 중간 상태를 유지하면서 파싱해야 하는 구조가 필수였음 → 그래서 DiffEntry 객체를 만들고 그걸 모아서 처리함