### PR TITLE
레포지토리 생성 시 post-receive 훅 스크립트 생성

### DIFF
--- a/src/main/java/com/example/gitserver/controller/BranchController.java
+++ b/src/main/java/com/example/gitserver/controller/BranchController.java
@@ -3,16 +3,16 @@ package com.example.gitserver.controller;
 import com.example.gitserver.dto.BranchDto;
 import com.example.gitserver.dto.CompareBranchResponseDto;
 import com.example.gitserver.dto.FileDto;
-import com.example.gitserver.dto.RepoInfoDto;
 import com.example.gitserver.service.BranchService;
-import com.example.gitserver.service.RepoService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+
 
 @RestController
 @RequestMapping("/branch")
@@ -34,7 +34,7 @@ public class BranchController {
             @PathVariable String base,
             @PathVariable String head
     ) {
-        List<CompareBranchResponseDto> branches = branchService.compareBranchHead(owner, repo,base,head);
+        List<CompareBranchResponseDto> branches = branchService.compareBranchHead(owner, repo, base, head);
         return ResponseEntity.ok(branches);
     }
 
@@ -45,10 +45,9 @@ public class BranchController {
             @PathVariable String base,
             @PathVariable String head
     ) {
-        List<FileDto> branches = branchService.getChangedFiles(owner, repo,base,head);
+        List<FileDto> branches = branchService.getChangedFiles(owner, repo, base, head);
         return ResponseEntity.ok(branches);
     }
-
 
 
 }


### PR DESCRIPTION
### ✨ 주요 변경 사항
- 레포지토리 생성 시 post-receive 훅 스크립트를 자동으로 생성하도록 구현

### ✔ 배운 점
- Git은 post-receive 훅 스크립트를 작성하면 푸시 이벤트 발생 시 자동으로 실행된다
```shell
#!/bin/bash  # Bash 스크립트 선언 – 이 줄이 있어야 리눅스에서 Bash로 실행됨

# Git이 푸시 정보 (oldrev, newrev, refname)를 넘기면 read로 각 값을 변수에 저장
# 여러 브랜치가 동시에 푸시될 가능성도 있어 while 루프 사용
while read oldrev newrev refname
do
  branch=$(echo $refname | sed 's|refs/heads/||')  # refs/heads/ 부분을 제거해 실제 브랜치 이름 추출
  echo "브랜치 $branch 에 푸시됨: $oldrev → $newrev"

  # 코드리뷰 서버로 HTTP POST 요청 전송
  curl -X POST http://code-review-server:8081/git \
       -H "Content-Type: application/json" \
       -d "{\"owner\": \"%s\", \"repo\": \"%s\", \"branch\": \"$branch\", \"from\": \"$oldrev\", \"to\": \"$newrev\"}"
done
```

- Bash 스크립트 문법과 Git 훅의 실행 구조를 학습함

### ✍ 고민한 점
- 푸시 이벤트 발생 시, 깃서버 내부의 Spring 서버를 거쳐 코드리뷰 서버로 알림을 전달할지 아니면 깃서버에서 직접 코드리뷰 서버로 알림을 보낼지 고민함
- 최종적으로 직접 코드리뷰 서버로 알림을 전송하는 방식을 선택함
→ 이유: 중간 서버를 거칠 경우 복잡도가 증가하고, 실질적인 중간 처리 로직이 불필요했고 직접 전송 방식이 구조적으로 더 단순했기 때문에